### PR TITLE
Sets virtualbox as default provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
 Vagrant.require_version '>= 1.6.0'
 
 Vagrant.configure(2) do |config|


### PR DESCRIPTION
If user has Vagrant's VMWare plugin installed, it always defaults to that.

Setting the env var within Vagrantfile forces Vagrant to default to virtualbox.
