### PR TITLE
Agent forwarding over SSH connections

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,6 +38,11 @@ Vagrant.configure(2) do |config|
   # The second parameter must be an absolute path of where to share the folder within the guest machine.
   # Finally the third parameter is a set of non-required options to configure synced folders.
   config.vm.synced_folder "public/", "/var/www/", group: 'www-data', :owner => "vagrant"
+  
+  # config.ssh.forward_agent 
+  #
+  # If true, agent forwarding over SSH connections is enabled. 
+  config.ssh.forward_agent = true
 
   # Run the main shell provisioner.
   config.vm.provision 'shell', run: 'always' do |s|


### PR DESCRIPTION
Use your local SSH keys on your Vagrant boxes, so that you don’t have to manage password-less keys for each box
