### PR TITLE
Use the kvm paravirt provider if Virtualbox >= 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Before launching your Dashbrew environment, you must install VirtualBox and Vagr
 
 * [Vagrant >= 1.6.5](http://www.vagrantup.com/)
 * [VirtualBox 4.3.x](https://www.virtualbox.org/)
+	* Note that installing Virtualbox 5.x is *strongly* recommended for better performance.
 * [Vagrant Hosts Provisioner plugin](https://github.com/mdkholy/vagrant-hosts-provisioner) for managing the /etc/hosts file of both the host and guest machines.
 	* ``$ vagrant plugin install vagrant-hosts-provisioner``
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,6 +29,15 @@ Vagrant.configure(2) do |config|
     vb.customize ["modifyvm", :id, "--cpus", "1"]
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+
+    # If Virtualbox is version 5.0.0 or higher, enable the kvm paravirtualization
+    # provider for better performance.
+    begin
+      if VagrantPlugins::ProviderVirtualBox::Driver::Meta.new.version >= "5.0.0"
+        vb.customize ['modifyvm', :id, '--paravirtprovider', 'kvm']
+      end
+    rescue Vagrant::Errors::VirtualBoxNotDetected
+    end
   end
 
   # Synced Folders


### PR DESCRIPTION
In my testing with a recent copy of Drupal 8, using Virtualbox's new (as of 5.0.0) kvm paravirt provider can improve performance by up to 4x (measured in page loads per second). If it's available, you should use it.
